### PR TITLE
fix: allow user to change password without MFA configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+
+# Lockfiles
+.terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.1.3 (2024-01-08)
+
+### Fixed
+
+*   Allow user to change password without MFA configured.
+
 ## v0.1.2 (2019-08-09)
 
 *   Resolves inability to assume roles across accounts.

--- a/groups/main.tf
+++ b/groups/main.tf
@@ -254,11 +254,13 @@ data "aws_iam_policy_document" "self_management" {
       "iam:DeleteVirtualMFADevice",
       "iam:EnableMFADevice",
       "iam:GetAccountPasswordPolicy",
+      "iam:GetLoginProfile",
       "iam:GetUser",
       "iam:ListMFADevices",
       "iam:ListUsers",
       "iam:ListVirtualMFADevices",
       "iam:ResyncMFADevice",
+      "iam:UpdateLoginProfile",
       "sts:GetSessionToken",
     ]
 


### PR DESCRIPTION
Where a user does not have a PGP and an administrator resets the password via API/console requiring a change of password upon first authentication (enforcing unknown password beyond the user), `GetLoginProfile` and `UpdateLoginProfile` is needed.